### PR TITLE
Register GeoMesa Iterators

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+geomesa-1.2.?/
+geomesa-accumulo-distributed-runtime-1.2.?.jar
+geomesa-dist-1.2.?-bin.tar.gz
+geomesa-tools-1.2.?-bin.tar.gz

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,25 +1,22 @@
 FROM quay.io/geodocker/accumulo:latest
 
-MAINTAINER Pomadchin Grigory, daunnc@gmail.com
+MAINTAINER Pomadchin Grigory <daunnc@gmail.com>
 
-ENV GEOMESA_VERSION 1.2.4
+ARG GEOMESA_VERSION
+ENV GEOMESA_VERSION ${GEOMESA_VERSION}
 ENV GEOMESA_DIST /opt/geomesa
+ENV GEOMESA_RUNTIME ${GEOMESA_DIST}/accumulo
 ENV GEOMESA_HOME ${GEOMESA_DIST}/tools
 ENV PATH="${GEOMESA_HOME}/bin:${PATH}"
 
+ADD geomesa-tools-${GEOMESA_VERSION}-bin.tar.gz /
+ADD geomesa-accumulo-distributed-runtime-${GEOMESA_VERSION}.jar ${GEOMESA_RUNTIME}/
+
 # GeoMesa Iterators
 RUN set -x \
-  && mkdir -p ${GEOMESA_DIST} \
-  && curl -sS -L http://repo.locationtech.org/content/repositories/geomesa-releases/org/locationtech/geomesa/geomesa-dist/${GEOMESA_VERSION}/geomesa-dist-${GEOMESA_VERSION}-bin.tar.gz \
-  | tar -zx -C ${GEOMESA_DIST} --strip-components=2  geomesa-${GEOMESA_VERSION}/dist \
-  && tar -xzf ${GEOMESA_DIST}/tools/geomesa-tools-${GEOMESA_VERSION}-bin.tar.gz --strip-components=1 -C ${GEOMESA_DIST}/tools \
-  && ${GEOMESA_DIST}/tools/bin/install-jai.sh \
-  && ${GEOMESA_DIST}/tools/bin/install-jline.sh \
-  && rm -f ${GEOMESA_DIST}/tools/geomesa-tools-${GEOMESA_VERSION}-bin.tar.gz \
-  && rm -rf ${GEOMESA_DIST}/gs-plugins \
-  && rm -rf ${GEOMESA_DIST}/hadoop \
-  && rm -rf ${GEOMESA_DIST}/web-services \
-  && rm -rf ${GEOMESA_DIST}/spark
+  && mv /geomesa-tools-${GEOMESA_VERSION} ${GEOMESA_HOME} \
+  && (echo yes | ${GEOMESA_DIST}/tools/bin/install-jai.sh) \
+  && (echo yes | ${GEOMESA_DIST}/tools/bin/install-jline.sh)
 
 COPY ./fs /
 ENTRYPOINT [ "/sbin/geomesa-entrypoint.sh" ]

--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,22 @@ BASE := $(subst -, ,$(notdir ${CURDIR}))
 ORG  := $(word 1, ${BASE})
 REPO := $(word 2, ${BASE})-$(word 3, ${BASE})
 IMG  := quay.io/${ORG}/${REPO}
+GEOMESA_VERSION := 1.2.4
 
-build:
-	docker build -t ${IMG}:latest	.
+build: geomesa-accumulo-distributed-runtime-${GEOMESA_VERSION}.jar geomesa-tools-${GEOMESA_VERSION}-bin.tar.gz
+	docker build \
+		--build-arg GEOMESA_VERSION=${GEOMESA_VERSION} \
+		-t ${IMG}:latest .
+
+geomesa-dist-${GEOMESA_VERSION}-bin.tar.gz:
+	curl -L -C - -O "https://repo.locationtech.org/content/repositories/geomesa-releases/org/locationtech/geomesa/geomesa-dist/${GEOMESA_VERSION}/geomesa-dist-${GEOMESA_VERSION}-bin.tar.gz"
+
+geomesa-tools-${GEOMESA_VERSION}-bin.tar.gz: geomesa-dist-${GEOMESA_VERSION}-bin.tar.gz
+	tar zxvf $<
+	cp geomesa-${GEOMESA_VERSION}/dist/tools/geomesa-tools-1.2.4-bin.tar.gz .
+
+geomesa-accumulo-distributed-runtime-${GEOMESA_VERSION}.jar: geomesa-tools-${GEOMESA_VERSION}-bin.tar.gz geomesa-dist-${GEOMESA_VERSION}-bin.tar.gz
+	cp geomesa-${GEOMESA_VERSION}/dist/accumulo/geomesa-accumulo-distributed-runtime-${GEOMESA_VERSION}.jar .
 
 publish: build
 	docker push ${IMG}:latest
@@ -17,3 +30,13 @@ test: build
 		&& wait_until_accumulo_is_available \
 		&& accumulo shell -p GisPwd -e 'info'"
 	docker-compose down
+
+clean:
+	rm -rf geomesa-${GEOMESA_VERSION}/
+
+cleaner: clean
+	rm -f geomesa-tools-${GEOMESA_VERSION}-bin.tar.gz
+	rm -f geomesa-accumulo-distributed-runtime-${GEOMESA_VERSION}.jar
+
+cleanest: cleaner
+	rm -f geomesa-dist-${GEOMESA_VERSION}-bin.tar.gz

--- a/fs/sbin/geomesa-entrypoint.sh
+++ b/fs/sbin/geomesa-entrypoint.sh
@@ -8,7 +8,7 @@ ROLE=${1:-}
 ACCUMULO_USER=${ACCUMULO_USER:-root}
 
 if [ $ROLE = "register" ]; then
-  wait_until_accumulo_is_available
+  wait_until_accumulo_is_available ${INSTANCE_NAME}
   accumulo shell -u ${ACCUMULO_USER} -p ${ACCUMULO_PASSWORD} -e \
     "createnamespace geomesa"
   accumulo shell -u ${ACCUMULO_USER} -p ${ACCUMULO_PASSWORD} -e \


### PR DESCRIPTION
These changes cause the GeoMesa iterators to be registered when the GeoMesa master comes up.  Also, the GeoMesa tarball is now downloaded to the host instead of in the container during the build process, which tightens-up the feedback loop by allowing the tarball to be kept (instead of re-downloaded).

This **does not** depend on geodocker/geodocker-accumulo#12, but my [consistent registration branch](https://github.com/jamesmcclain/geodocker-accumulo-geomesa/tree/fix/make-registration-consistent) does depend on that PR and this one.  That branch has not been made into a a PR, because it will fail without geodocker/geodocker-accumulo#12.
